### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/geo_sampling/geo_roads.py
+++ b/geo_sampling/geo_roads.py
@@ -192,7 +192,7 @@ def bbbike_generate_extract_link(args):
             new_len = line.length / BBBIKE_MAX_POINTS
             new_line = redistribute_vertices(line, new_len)
             for lat, lng in new_line.coords:
-                points.append('%.3f,%.3f' % (lat, lng))
+                points.append('{0:.3f},{1:.3f}'.format(lat, lng))
             coords = '|'.join(points)
             sw_lng, sw_lat, ne_lng, ne_lat = s.shape.bbox
             city = args.ccode + '_' + args.name
@@ -353,12 +353,12 @@ def main(argv=sys.argv[1:]):
 
     lng, lat = sr[0].shape.points[0]
     a, b, zone_x, zone_y = utm.from_latlon(lat, lng)
-    utm_zone = "%d%s" % (zone_x, zone_y)
+    utm_zone = "{0:d}{1!s}".format(zone_x, zone_y)
 
     wgs2utm = partial(pyproj.transform, pyproj.Proj("+init=EPSG:4326"),
-                      pyproj.Proj("+proj=utm +zone=%s" % utm_zone))
-    utm2wgs = partial(pyproj.transform, pyproj.Proj("+proj=utm +zone=%s" %
-                      utm_zone), pyproj.Proj("+init=EPSG:4326"))
+                      pyproj.Proj("+proj=utm +zone={0!s}".format(utm_zone)))
+    utm2wgs = partial(pyproj.transform, pyproj.Proj("+proj=utm +zone={0!s}".format(
+                      utm_zone)), pyproj.Proj("+init=EPSG:4326"))
 
     uid = 0
     road_types = args.types


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:geo_sampling?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:geo_sampling?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)